### PR TITLE
add optional serde dependency

### DIFF
--- a/ipp/Cargo.toml
+++ b/ipp/Cargo.toml
@@ -22,6 +22,7 @@ num-traits = "0.2"
 bytes = "1"
 thiserror = "1"
 http = "0.2"
+serde = { version = "1.0", optional = true, features = ["derive"] }
 
 [dependencies.futures-util]
 version = "0.3"
@@ -49,3 +50,4 @@ default = ["client", "tls"]
 client = ["async", "reqwest", "tokio-util"]
 async = ["futures-util", "futures-executor"]
 tls = ["reqwest/native-tls"]
+serde = ["dep:serde", "bytes/serde"]

--- a/ipp/src/attribute.rs
+++ b/ipp/src/attribute.rs
@@ -3,6 +3,8 @@
 //!
 use std::collections::HashMap;
 
+#[cfg(feature = "serde")]
+use serde::{Serialize, Deserialize};
 use bytes::{BufMut, Bytes, BytesMut};
 
 use crate::{model::DelimiterTag, value::IppValue};
@@ -12,6 +14,7 @@ fn is_header_attr(attr: &str) -> bool {
 }
 
 /// `IppAttribute` represents an IPP attribute
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug)]
 pub struct IppAttribute {
     /// Attribute name
@@ -134,6 +137,7 @@ impl IppAttribute {
 }
 
 /// Attribute group
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug)]
 pub struct IppAttributeGroup {
     tag: DelimiterTag,
@@ -166,6 +170,7 @@ impl IppAttributeGroup {
 }
 
 /// Attribute list
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Default)]
 pub struct IppAttributes {
     groups: Vec<IppAttributeGroup>,

--- a/ipp/src/lib.rs
+++ b/ipp/src/lib.rs
@@ -55,6 +55,9 @@
 use bytes::{BufMut, Bytes, BytesMut};
 use num_traits::FromPrimitive;
 
+#[cfg(feature = "serde")]
+use serde::{Serialize, Deserialize};
+
 use crate::model::{IppVersion, StatusCode};
 
 pub mod attribute;
@@ -93,6 +96,7 @@ pub mod prelude {
 }
 
 /// IPP request and response header
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug)]
 pub struct IppHeader {
     /// IPP protocol version

--- a/ipp/src/model.rs
+++ b/ipp/src/model.rs
@@ -3,9 +3,13 @@
 //!
 use std::fmt;
 
+#[cfg(feature = "serde")]
+use serde::{Serialize, Deserialize};
+
 use enum_primitive_derive::Primitive;
 
 /// IPP protocol version
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct IppVersion(pub u16);
 
@@ -28,6 +32,7 @@ impl IppVersion {
 }
 
 /// IPP operation constants
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Primitive, Debug, Copy, Clone, PartialEq)]
 #[allow(clippy::upper_case_acronyms)]
 pub enum Operation {
@@ -117,6 +122,7 @@ pub enum JobState {
 }
 
 /// group delimiter tags
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Primitive, Debug, Copy, Clone, PartialEq, Hash, Eq)]
 pub enum DelimiterTag {
     OperationAttributes = 0x01,
@@ -127,6 +133,7 @@ pub enum DelimiterTag {
 }
 
 /// IPP value tags
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Primitive, Debug, Copy, Clone, PartialEq)]
 pub enum ValueTag {
     Unsupported = 0x10,

--- a/ipp/src/payload.rs
+++ b/ipp/src/payload.rs
@@ -54,6 +54,12 @@ impl IppPayload {
     }
 }
 
+impl Default for IppPayload {
+    fn default() -> Self {
+        Self { inner: PayloadKind::Empty }
+    }
+}
+
 #[cfg(feature = "async")]
 impl AsyncRead for IppPayload {
     fn poll_read(mut self: Pin<&mut Self>, cx: &mut Context, buf: &mut [u8]) -> Poll<io::Result<usize>> {

--- a/ipp/src/request.rs
+++ b/ipp/src/request.rs
@@ -3,6 +3,8 @@
 //!
 use std::io::{self, Read};
 
+#[cfg(feature = "serde")]
+use serde::{Serialize, Deserialize};
 use bytes::{BufMut, Bytes, BytesMut};
 #[cfg(feature = "async")]
 use futures_util::io::{AsyncRead, AsyncReadExt};
@@ -18,9 +20,11 @@ use crate::{
 };
 
 /// IPP request/response struct
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct IppRequestResponse {
     pub(crate) header: IppHeader,
     pub(crate) attributes: IppAttributes,
+    #[cfg_attr(feature = "serde", serde(skip))]
     pub(crate) payload: IppPayload,
 }
 

--- a/ipp/src/value.rs
+++ b/ipp/src/value.rs
@@ -3,12 +3,15 @@
 //!
 use std::{convert::Infallible, fmt, io, str::FromStr};
 
+#[cfg(feature = "serde")]
+use serde::{Serialize, Deserialize};
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 use enum_as_inner::EnumAsInner;
 
 use crate::{model::ValueTag, FromPrimitive as _};
 
 /// IPP attribute values as defined in [RFC 8010](https://tools.ietf.org/html/rfc8010)
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, PartialEq, EnumAsInner)]
 pub enum IppValue {
     Integer(i32),


### PR DESCRIPTION
Basically what the title says: add an optional serde dependency for serialization / deserialization support. Would make it possible to create IPP packets, say, for testing, for example from JSON.