### PR TITLE
Derive Eq and Hash for IppValue

### DIFF
--- a/ipp/src/value.rs
+++ b/ipp/src/value.rs
@@ -20,7 +20,7 @@ fn get_len_string(data: &mut Bytes) -> String {
 
 /// IPP attribute values as defined in [RFC 8010](https://tools.ietf.org/html/rfc8010)
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, PartialEq, EnumAsInner)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, EnumAsInner)]
 pub enum IppValue {
     Integer(i32),
     Enum(i32),


### PR DESCRIPTION
This is a proposal to derive Eq and Hash for IppValue, making it possible to put IppValues into a HashSet (i.e. for deduplication). 

This would be similar to, say, [serde_json's Value implementing Eq](https://docs.rs/serde_json/latest/serde_json/enum.Value.html#impl-Eq-for-Value).

The only possible drawback I am currently seeing is the ambiguity whether an IppValue::Array (ipp's `1set of X`) should be considered ordered or unordered for the purpose of Eq and Hash. Currently, it's considered ordered. The spec explicitly [states](https://datatracker.ietf.org/doc/html/rfc8011#section-5.1.18) that sets are "normally unordered; however, each attribute description of this type can specify that the values MUST be in a certain order for that attribute". So it is certainly useful for programs to be able to determine the order (so a `Vec` seems like the right choice) but users should be aware that this will have implications for Eq and Hash. 