### PR TITLE
add into_ methods to attribute models

### DIFF
--- a/ipp/src/attribute.rs
+++ b/ipp/src/attribute.rs
@@ -127,6 +127,11 @@ impl IppAttribute {
         &self.value
     }
 
+    /// Consume this attribute and return the value
+    pub fn into_value(self) -> IppValue {
+        self.value
+    }
+
     /// Write attribute to byte array
     pub fn to_bytes(&self) -> Bytes {
         let mut buffer = BytesMut::new();
@@ -170,6 +175,11 @@ impl IppAttributeGroup {
     pub fn attributes_mut(&mut self) -> &mut HashMap<String, IppAttribute> {
         &mut self.attributes
     }
+
+    /// Consume this group and return mutable attributes
+    pub fn into_attributes(self) -> HashMap<String, IppAttribute> {
+        self.attributes
+    }
 }
 
 /// Attribute list
@@ -193,6 +203,11 @@ impl IppAttributes {
     /// Get all mutable groups
     pub fn groups_mut(&mut self) -> &mut Vec<IppAttributeGroup> {
         &mut self.groups
+    }
+
+    /// Consume this attribute list and return all attribute groups
+    pub fn into_groups(self) -> Vec<IppAttributeGroup> {
+        self.groups
     }
 
     /// Get a list of attribute groups matching a given delimiter tag


### PR DESCRIPTION
Just some useful methods to consume Ipp Model objects for their inner values. Currently, the only way to deconstruct IppAttributes / IppAttribute / IppAttributeGroup is to use `std::mem::take` with `groups_mut` etc. since the members are private.

## Alternatives

- making the fields `pub` instead of adding `into_` methods
- `std::mem::take` with the `_mut` methods
- Cloning

P.S.: Sorry for the PR spam; I am currently heavily relying on `ipp.rs` for my upcoming IPP server implementation and that's where they are all coming from. If you prefer "bulky" PR's instead of smaller separate ones let me know.