### PR TITLE
fix unsupported attributes not being sent

### DIFF
--- a/ipp/src/attribute.rs
+++ b/ipp/src/attribute.rs
@@ -242,26 +242,21 @@ impl IppAttributes {
                     buffer.put(attr.to_bytes());
                 }
             }
+
+            // now the other operation attributes
+            for attr in group.attributes().values() {
+                if !is_header_attr(attr.name()) {
+                    buffer.put(attr.to_bytes());
+                }
+            }
         }
 
         // now the rest
-        for hdr in &[
-            DelimiterTag::OperationAttributes,
-            DelimiterTag::JobAttributes,
-            DelimiterTag::PrinterAttributes,
-        ] {
-            if let Some(group) = self.groups_of(*hdr).next() {
-                if group.tag() != DelimiterTag::OperationAttributes {
-                    buffer.put_u8(group.tag() as u8);
-                }
-                let attrs = group
-                    .attributes()
-                    .iter()
-                    .filter(|&(_, v)| group.tag() != DelimiterTag::OperationAttributes || !is_header_attr(v.name()));
+        for group in self.groups().iter().filter(|group| group.tag() != DelimiterTag::OperationAttributes) {
+            buffer.put_u8(group.tag() as u8);
 
-                for (_, attr) in attrs {
-                    buffer.put(attr.to_bytes());
-                }
+            for attr in group.attributes().values() {
+                buffer.put(attr.to_bytes());
             }
         }
         buffer.put_u8(DelimiterTag::EndOfAttributes as u8);


### PR DESCRIPTION
Currently, when serializing an IppRequest or IppResponse, the handling of the attributes is a bit off:

- if there are multiple attribute groups with the same tag, only one is serialized (this can happen, for instance with the Get-Jobs operation, where each job gets its own group)
- the unsupported attributes group is not sent at all
- the order of the groups can be not as intended

This PR attempts to fix those while maintaining the existing behavior of sending some special operation attributes first.
If there are multiple groups with the same tag, they are all sent in order they were added (except for the operation attributes, which are sent first and of which only one group will be sent).