### PR TITLE
Remove unused Sync trait bound on Reader and Parser

### DIFF
--- a/ipp/src/parser.rs
+++ b/ipp/src/parser.rs
@@ -162,7 +162,7 @@ pub struct AsyncIppParser<R> {
 #[cfg(feature = "async")]
 impl<R> AsyncIppParser<R>
 where
-    R: AsyncRead + Send + Sync + Unpin,
+    R: AsyncRead + Send + Unpin,
 {
     /// Create an IPP parser from AsyncIppReader
     pub fn new<T>(reader: T) -> AsyncIppParser<R>
@@ -233,7 +233,7 @@ pub struct IppParser<R> {
 
 impl<R> IppParser<R>
 where
-    R: 'static + Read + Send + Sync,
+    R: 'static + Read + Send,
 {
     /// Create an IPP parser from IppReader
     pub fn new<T>(reader: T) -> IppParser<R>

--- a/ipp/src/payload.rs
+++ b/ipp/src/payload.rs
@@ -14,8 +14,8 @@ use {
 
 enum PayloadKind {
     #[cfg(feature = "async")]
-    Async(Box<dyn AsyncRead + Send + Sync + Unpin>),
-    Sync(Box<dyn Read + Send + Sync>),
+    Async(Box<dyn AsyncRead + Send + Unpin>),
+    Sync(Box<dyn Read + Send>),
     Empty,
 }
 
@@ -36,7 +36,7 @@ impl IppPayload {
     /// Create an async payload from the AsyncRead object
     pub fn new_async<R>(r: R) -> Self
     where
-        R: 'static + AsyncRead + Send + Sync + Unpin,
+        R: 'static + AsyncRead + Send + Unpin,
     {
         IppPayload {
             inner: PayloadKind::Async(Box::new(r)),
@@ -46,7 +46,7 @@ impl IppPayload {
     /// Create a sync payload from the Read object
     pub fn new<R>(r: R) -> Self
     where
-        R: 'static + Read + Send + Sync,
+        R: 'static + Read + Send,
     {
         IppPayload {
             inner: PayloadKind::Sync(Box::new(r)),

--- a/ipp/src/reader.rs
+++ b/ipp/src/reader.rs
@@ -19,7 +19,7 @@ pub struct AsyncIppReader<R> {
 #[cfg(feature = "async")]
 impl<R> AsyncIppReader<R>
 where
-    R: AsyncRead + Send + Sync + Unpin,
+    R: AsyncRead + Send + Unpin,
 {
     /// Create an IppReader from an AsyncRead instance
     pub fn new(inner: R) -> Self {
@@ -99,7 +99,7 @@ where
 #[cfg(feature = "async")]
 impl<R> From<R> for AsyncIppReader<R>
 where
-    R: AsyncRead + Send + Sync + Unpin,
+    R: AsyncRead + Send + Unpin,
 {
     fn from(r: R) -> Self {
         AsyncIppReader::new(r)
@@ -113,7 +113,7 @@ pub struct IppReader<R> {
 
 impl<R> IppReader<R>
 where
-    R: Read + Send + Sync,
+    R: Read + Send,
 {
     /// Create an IppReader from a Read instance
     pub fn new(inner: R) -> Self {
@@ -190,7 +190,7 @@ where
 
 impl<R> From<R> for IppReader<R>
 where
-    R: Read + Send + Sync,
+    R: Read + Send,
 {
     fn from(r: R) -> Self {
         IppReader::new(r)

--- a/ipp/src/request.rs
+++ b/ipp/src/request.rs
@@ -149,7 +149,7 @@ impl IppRequestResponse {
 
     #[cfg(feature = "async")]
     /// Convert the request/response into AsyncRead including the payload
-    pub fn into_async_read(self) -> impl AsyncRead + Send + Sync + 'static {
+    pub fn into_async_read(self) -> impl AsyncRead + Send + 'static {
         let header = self.to_bytes();
         trace!("IPP header size: {}", header.len());
 
@@ -157,7 +157,7 @@ impl IppRequestResponse {
     }
 
     /// Convert the request/response into Read including the payload
-    pub fn into_read(self) -> impl Read + Send + Sync + 'static {
+    pub fn into_read(self) -> impl Read + Send + 'static {
         let header = self.to_bytes();
         trace!("IPP header size: {}", header.len());
 


### PR DESCRIPTION
When trying to use this crate with axum:
```rust
pub struct IppRequest(IppRequestResponse);

impl<S> FromRequest<S> for IppRequest
where
    S: Send + Sync,
{
    type Rejection = Response;

    async fn from_request(req: Request, _state: &S) -> Result<Self, Self::Rejection> {
        let body = req.into_body();
        let read_body = body.into_data_stream().map_err(io::Error::other).into_async_read();
        let reader = AsyncIppReader::new(read_body);
        let parser = AsyncIppParser::new(reader);

        parser.parse().await.map_err(|_e| todo!()).map(Self)
    }
}
```

I had an error because `read_body` is not `Sync`, but the trait is required by `AsyncIppReader`, which is basically [this error](https://stackoverflow.com/questions/77882516/why-with-axum-v0-7-the-stream-is-no-sync-anymore). Removing the trait bound still compiles so it seems it is not actually needed as in the linked ticket, but it does fix the issue.