### PR TITLE
chrono date with name

### DIFF
--- a/ipp/src/attribute.rs
+++ b/ipp/src/attribute.rs
@@ -405,3 +405,10 @@ impl IppAttrWithName for IppDateTime {
         IppValue::DateTime(self).with_name(name)
     }
 }
+
+#[cfg(feature = "chrono")]
+impl<Tz: chrono::TimeZone> IppAttrWithName for chrono::DateTime<Tz> {
+    fn with_name<S: Into<String>>(self, name: S) -> Result<IppAttribute, IppParseError> {
+        IppDateTime::from(self).with_name(name)
+    }
+}


### PR DESCRIPTION
Add chrono::DateTime as a possible input of the `IppAttrWithName` trait. Doesn't add much but it's in the logic of targetting types with an unambiguous conversion.