### PR TITLE
Add helper functions for creating enums and groups

### DIFF
--- a/ipp/src/attribute.rs
+++ b/ipp/src/attribute.rs
@@ -292,6 +292,21 @@ impl IppAttributes {
         self.groups.iter().filter(move |g| g.tag == tag)
     }
 
+    /// Get a list of mutable attribute groups matching a given delimiter tag
+    pub fn groups_of_mut(&mut self, tag: DelimiterTag) -> impl Iterator<Item = &mut IppAttributeGroup> {
+        self.groups.iter_mut().filter(move |g| g.tag == tag)
+    }
+
+    /// Get the first group that matches the delimiter
+    pub fn first_of(&self, tag: DelimiterTag) -> Option<&IppAttributeGroup> {
+        self.groups_of(tag).next()
+    }
+
+    /// Get a mutable access to the first group that matches the delimiter
+    pub fn first_of_mut(&mut self, tag: DelimiterTag) -> Option<&mut IppAttributeGroup> {
+        self.groups_of_mut(tag).next()
+    }
+
     /// Add an attribute to a given group
     pub fn add(&mut self, tag: DelimiterTag, attribute: IppAttribute) {
         let group = self.groups_mut().iter_mut().find(|g| g.tag() == tag);

--- a/ipp/src/parser.rs
+++ b/ipp/src/parser.rs
@@ -39,10 +39,14 @@ pub enum IppParseError {
     #[error(transparent)]
     InvalidIntValue(#[from] TryFromIntError),
 
+    /// The enum value is out of the allowed range for IPP.
+    #[error("Invalid enum value")]
+    InvalidEnumValue,
+
     #[error(transparent)]
     IoError(#[from] io::Error),
 
-    #[error("infallible this should never happen")]
+    #[error("Infallible this should never happen")]
     Infallible(#[from] Infallible),
 
     #[error("Found a non-utf-8 string in a context that currently only supports utf-8")]

--- a/ipp/src/value.rs
+++ b/ipp/src/value.rs
@@ -7,6 +7,7 @@ use std::{borrow::Cow, collections::BTreeMap, fmt, ops::Deref, str::FromStr};
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 use enum_as_inner::EnumAsInner;
 use http::Uri;
+use num_traits::ToPrimitive;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
@@ -508,11 +509,8 @@ impl IppValue {
         Self::Integer(value)
     }
 
-    pub fn new_enum<V: TryInto<i32>>(value: V) -> Result<Self, IppParseError> {
-        value
-            .try_into()
-            .map(Self::Enum)
-            .or(Err(IppParseError::InvalidEnumValue))
+    pub fn new_enum<V: ToPrimitive>(value: V) -> Result<Self, IppParseError> {
+        value.to_i32().map(Self::Enum).ok_or(IppParseError::InvalidEnumValue)
     }
 
     pub fn new_octet_string(data: Bytes) -> Self {

--- a/ipp/src/value.rs
+++ b/ipp/src/value.rs
@@ -508,8 +508,11 @@ impl IppValue {
         Self::Integer(value)
     }
 
-    pub fn new_enum(value: i32) -> Self {
-        Self::Enum(value)
+    pub fn new_enum<V: TryInto<i32>>(value: V) -> Result<Self, IppParseError> {
+        value
+            .try_into()
+            .map(Self::Enum)
+            .or(Err(IppParseError::InvalidEnumValue))
     }
 
     pub fn new_octet_string(data: Bytes) -> Self {


### PR DESCRIPTION
Change the signature of `IppValue::new_enum()` so that an enum can be used as a parameter.  Makes it possible to write
`let value = IppValue::Enum(Finishings::None)?;` instead of `let value = IppValue::Enum(Finishings::None as i32);`

Add `first_of` methods for accessing attribute groups, since there's supposed to be only one anyway. Add mutable variations