### PR TITLE
Const time string checks to remove need for unwrap and results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 8.0.0
+- Added `BoundedStrLiteral`, a static version of `BoundedString` that allows compile-time check of string size.
+- Change the type of all `IppAttribute` constant names from `&'static str` to `BoundedStrLiteral`
+
 ## 7.0.0
 - Refactored attribute storage to use an ordered list instead of a `HashMap`, preserving attribute order ([#54](https://github.com/ancwrd1/ipp.rs/issues/54))
 - Added `IppAttributes::set_or_replace`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -727,7 +727,7 @@ checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
 name = "ipp"
-version = "7.0.0"
+version = "8.0.0"
 dependencies = [
  "base64 0.23.1",
  "bytes",
@@ -752,7 +752,7 @@ dependencies = [
 
 [[package]]
 name = "ipp-examples"
-version = "7.0.0"
+version = "8.0.0"
 dependencies = [
  "ipp",
  "tokio",
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "ipp-util"
-version = "7.0.0"
+version = "8.0.0"
 dependencies = [
  "clap",
  "ipp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [ "ipp", "util", "examples" ]
 resolver = "2"
 
 [workspace.package]
-version = "7.0.0"
+version = "8.0.0"
 authors = ["Dmitry Pankratov <dmitry@pankratov.net>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/ancwrd1/ipp.rs"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -36,6 +36,6 @@ path = "src/print-job.rs"
 name = "print-job"
 
 [dependencies]
-ipp = { path = "../ipp", version = "7", features = ["client-tls"] }
+ipp = { path = "../ipp", version = "8", features = ["client-tls"] }
 tokio = { version = "1", features = ["macros", "fs", "rt-multi-thread"] }
 tokio-util = { version = "0.7", features = ["compat"] }

--- a/examples/src/multi-doc.rs
+++ b/examples/src/multi-doc.rs
@@ -30,7 +30,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .attributes()
         .groups_of(DelimiterTag::PrinterAttributes)
         .next()
-        .and_then(|g| g.get(&IppAttribute::OPERATIONS_SUPPORTED))
+        .and_then(|g| g.get(IppAttribute::OPERATIONS_SUPPORTED))
         .ok_or(IppError::MissingAttribute)?;
 
     if !ops_attr.value().into_iter().any(supports_multi_doc) {
@@ -46,7 +46,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .attributes()
         .groups_of(DelimiterTag::JobAttributes)
         .next()
-        .and_then(|g| g.get(&IppAttribute::JOB_ID))
+        .and_then(|g| g.get(IppAttribute::JOB_ID))
         .and_then(|attr| attr.value().as_integer())
         .ok_or(IppError::MissingAttribute)?;
 

--- a/examples/src/multi-doc.rs
+++ b/examples/src/multi-doc.rs
@@ -30,7 +30,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .attributes()
         .groups_of(DelimiterTag::PrinterAttributes)
         .next()
-        .and_then(|g| g.get(IppAttribute::OPERATIONS_SUPPORTED))
+        .and_then(|g| g.get(&IppAttribute::OPERATIONS_SUPPORTED))
         .ok_or(IppError::MissingAttribute)?;
 
     if !ops_attr.value().into_iter().any(supports_multi_doc) {
@@ -46,7 +46,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .attributes()
         .groups_of(DelimiterTag::JobAttributes)
         .next()
-        .and_then(|g| g.get(IppAttribute::JOB_ID))
+        .and_then(|g| g.get(&IppAttribute::JOB_ID))
         .and_then(|attr| attr.value().as_integer())
         .ok_or(IppError::MissingAttribute)?;
 

--- a/examples/src/print-job-async.rs
+++ b/examples/src/print-job-async.rs
@@ -1,6 +1,6 @@
 use std::{env, error::Error, process::exit};
 
-use ipp::prelude::*;
+use ipp::{prelude::*, value::IppName};
 use tokio::fs::File;
 use tokio_util::compat::TokioAsyncReadCompatExt;
 
@@ -22,7 +22,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     for arg in &args[3..] {
         if let Some((k, v)) = arg.split_once('=') {
-            builder = builder.attribute(IppAttribute::new(k.try_into()?, v.parse()?));
+            builder = builder.attribute(IppAttribute::new(IppName::try_from(k)?, v.parse()?));
         }
     }
 

--- a/examples/src/print-job.rs
+++ b/examples/src/print-job.rs
@@ -1,6 +1,6 @@
 use std::{env, error::Error, fs, process::exit};
 
-use ipp::prelude::*;
+use ipp::{prelude::*, value::IppName};
 
 fn main() -> Result<(), Box<dyn Error>> {
     let args: Vec<_> = env::args().collect();
@@ -19,7 +19,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     for arg in &args[3..] {
         if let Some((k, v)) = arg.split_once('=') {
-            builder = builder.attribute(IppAttribute::new(k.try_into()?, v.parse()?));
+            builder = builder.attribute(IppAttribute::new(IppName::try_from(k)?, v.parse()?));
         }
     }
 

--- a/ipp/src/attribute.rs
+++ b/ipp/src/attribute.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     model::DelimiterTag,
     parser::IppParseError,
-    value::{BoundedStr, IppDateTime, IppName, IppValue},
+    value::{BoundedStrLiteral, IppDateTime, IppName, IppValue},
 };
 
 macro_rules! define_attributes {
@@ -24,7 +24,7 @@ fn is_header_attr(attr: &str) -> bool {
     IppAttribute::HEADER_ATTRS.contains(&attr)
 }
 
-pub type IppAttributeName = BoundedStr<255>;
+pub type IppAttributeName = BoundedStrLiteral<255>;
 
 /// `IppAttribute` represents an IPP attribute
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/ipp/src/attribute.rs
+++ b/ipp/src/attribute.rs
@@ -21,7 +21,7 @@ macro_rules! define_attributes {
 }
 
 fn is_header_attr(attr: &str) -> bool {
-    IppAttribute::HEADER_ATTRS.contains(&attr)
+    IppAttribute::HEADER_ATTRS.iter().any(|a| a.inner == attr)
 }
 
 pub type IppAttributeName = BoundedStrLiteral<255>;
@@ -189,11 +189,11 @@ impl IppAttribute {
     //    attributes (i.e., the "printer-uri" and "job-id" attributes), the
     //    "printer-uri" attribute MUST be the third attribute and the
     //    "job-id" attribute MUST be the fourth attribute.
-    const HEADER_ATTRS: [&'static str; 4] = [
-        IppAttribute::ATTRIBUTES_CHARSET.inner,
-        IppAttribute::ATTRIBUTES_NATURAL_LANGUAGE.inner,
-        IppAttribute::PRINTER_URI.inner,
-        IppAttribute::JOB_ID.inner,
+    const HEADER_ATTRS: [IppAttributeName; 4] = [
+        IppAttribute::ATTRIBUTES_CHARSET,
+        IppAttribute::ATTRIBUTES_NATURAL_LANGUAGE,
+        IppAttribute::PRINTER_URI,
+        IppAttribute::JOB_ID,
     ];
 
     /// Create a new instance of the attribute
@@ -404,7 +404,7 @@ impl IppAttributes {
             for attr in &group.attributes {
                 if let Some(idx) = IppAttribute::HEADER_ATTRS
                     .iter()
-                    .position(|h| *h == attr.name().as_str())
+                    .position(|h| h.inner == attr.name().as_str())
                 {
                     header_slots[idx] = Some(attr);
                 }

--- a/ipp/src/attribute.rs
+++ b/ipp/src/attribute.rs
@@ -285,8 +285,10 @@ impl IppAttributeGroup {
         self.attributes
     }
 
-    pub fn get(&self, name: &str) -> Option<&IppAttribute> {
-        self.attributes.iter().find(|attr| attr.name().as_str() == name)
+    pub fn get(&self, name: impl AsRef<str>) -> Option<&IppAttribute> {
+        self.attributes
+            .iter()
+            .find(|attr| attr.name().as_str() == name.as_ref())
     }
 }
 

--- a/ipp/src/attribute.rs
+++ b/ipp/src/attribute.rs
@@ -11,18 +11,20 @@ use serde::{Deserialize, Serialize};
 use crate::{
     model::DelimiterTag,
     parser::IppParseError,
-    value::{IppDateTime, IppName, IppValue},
+    value::{BoundedStr, IppDateTime, IppName, IppValue},
 };
 
 macro_rules! define_attributes {
     ($($name:ident => $value:literal),* $(,)?) => {
-        $(pub const $name: &'static str = $value;)*
+        $(pub const $name: IppAttributeName = IppAttributeName::const_new($value);)*
     };
 }
 
 fn is_header_attr(attr: &str) -> bool {
     IppAttribute::HEADER_ATTRS.contains(&attr)
 }
+
+pub type IppAttributeName = BoundedStr<255>;
 
 /// `IppAttribute` represents an IPP attribute
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -188,18 +190,21 @@ impl IppAttribute {
     //    "printer-uri" attribute MUST be the third attribute and the
     //    "job-id" attribute MUST be the fourth attribute.
     const HEADER_ATTRS: [&'static str; 4] = [
-        IppAttribute::ATTRIBUTES_CHARSET,
-        IppAttribute::ATTRIBUTES_NATURAL_LANGUAGE,
-        IppAttribute::PRINTER_URI,
-        IppAttribute::JOB_ID,
+        IppAttribute::ATTRIBUTES_CHARSET.inner,
+        IppAttribute::ATTRIBUTES_NATURAL_LANGUAGE.inner,
+        IppAttribute::PRINTER_URI.inner,
+        IppAttribute::JOB_ID.inner,
     ];
 
     /// Create a new instance of the attribute
     ///
     /// * `name` - Attribute name<br/>
     /// * `value` - Attribute value<br/>
-    pub fn new(name: IppName, value: IppValue) -> IppAttribute {
-        IppAttribute { name, value }
+    pub fn new(name: impl Into<IppName>, value: IppValue) -> IppAttribute {
+        IppAttribute {
+            name: name.into(),
+            value,
+        }
     }
 
     /// Create a new instance of the attribute

--- a/ipp/src/operation.rs
+++ b/ipp/src/operation.rs
@@ -20,7 +20,7 @@ fn with_user_name(user_name: Option<IppName>, req: &mut IppRequestResponse) {
         req.attributes_mut().add(
             DelimiterTag::OperationAttributes,
             IppAttribute::new(
-                IppAttribute::REQUESTING_USER_NAME.try_into().unwrap(),
+                IppAttribute::REQUESTING_USER_NAME,
                 IppValue::NameWithoutLanguage(user_name),
             ),
         );
@@ -31,10 +31,7 @@ fn with_document_format(document_format: Option<IppMimeMediaType>, req: &mut Ipp
     if let Some(document_format) = document_format {
         req.attributes_mut().add(
             DelimiterTag::OperationAttributes,
-            IppAttribute::new(
-                IppAttribute::DOCUMENT_FORMAT.try_into().unwrap(),
-                IppValue::MimeMediaType(document_format),
-            ),
+            IppAttribute::new(IppAttribute::DOCUMENT_FORMAT, IppValue::MimeMediaType(document_format)),
         );
     }
 }
@@ -113,10 +110,7 @@ impl IppOperation for PrintJob {
         if let Some(job_name) = self.job_name {
             retval.attributes_mut().add(
                 DelimiterTag::OperationAttributes,
-                IppAttribute::new(
-                    IppAttribute::JOB_NAME.try_into().unwrap(),
-                    IppValue::NameWithoutLanguage(job_name),
-                ),
+                IppAttribute::new(IppAttribute::JOB_NAME, IppValue::NameWithoutLanguage(job_name)),
             )
         }
 
@@ -174,10 +168,7 @@ impl IppOperation for GetPrinterAttributes {
             let vals: Vec<IppValue> = self.attributes.into_iter().map(IppValue::Keyword).collect();
             retval.attributes_mut().add(
                 DelimiterTag::OperationAttributes,
-                IppAttribute::new(
-                    IppAttribute::REQUESTED_ATTRIBUTES.try_into().unwrap(),
-                    IppValue::Array(vals),
-                ),
+                IppAttribute::new(IppAttribute::REQUESTED_ATTRIBUTES, IppValue::Array(vals)),
             );
         }
 
@@ -221,10 +212,7 @@ impl IppOperation for CreateJob {
         if let Some(job_name) = self.job_name {
             retval.attributes_mut().add(
                 DelimiterTag::OperationAttributes,
-                IppAttribute::new(
-                    IppAttribute::JOB_NAME.try_into().unwrap(),
-                    IppValue::NameWithoutLanguage(job_name),
-                ),
+                IppAttribute::new(IppAttribute::JOB_NAME, IppValue::NameWithoutLanguage(job_name)),
             )
         }
 
@@ -285,15 +273,12 @@ impl IppOperation for SendDocument {
 
         retval.attributes_mut().add(
             DelimiterTag::OperationAttributes,
-            IppAttribute::new(IppAttribute::JOB_ID.try_into().unwrap(), IppValue::Integer(self.job_id)),
+            IppAttribute::new(IppAttribute::JOB_ID, IppValue::Integer(self.job_id)),
         );
 
         retval.attributes_mut().add(
             DelimiterTag::OperationAttributes,
-            IppAttribute::new(
-                IppAttribute::LAST_DOCUMENT.try_into().unwrap(),
-                IppValue::Boolean(self.last),
-            ),
+            IppAttribute::new(IppAttribute::LAST_DOCUMENT, IppValue::Boolean(self.last)),
         );
 
         with_user_name(self.user_name, &mut retval);
@@ -367,7 +352,7 @@ impl IppOperation for CancelJob {
         let mut retval = IppRequestResponse::new_internal(self.version(), Operation::CancelJob, Some(self.printer_uri));
         retval.attributes_mut().add(
             DelimiterTag::OperationAttributes,
-            IppAttribute::new(IppAttribute::JOB_ID.try_into().unwrap(), IppValue::Integer(self.job_id)),
+            IppAttribute::new(IppAttribute::JOB_ID, IppValue::Integer(self.job_id)),
         );
         with_user_name(self.user_name, &mut retval);
         retval
@@ -405,7 +390,7 @@ impl IppOperation for GetJobAttributes {
             IppRequestResponse::new_internal(self.version(), Operation::GetJobAttributes, Some(self.printer_uri));
         retval.attributes_mut().add(
             DelimiterTag::OperationAttributes,
-            IppAttribute::new(IppAttribute::JOB_ID.try_into().unwrap(), IppValue::Integer(self.job_id)),
+            IppAttribute::new(IppAttribute::JOB_ID, IppValue::Integer(self.job_id)),
         );
         with_user_name(self.user_name, &mut retval);
         retval

--- a/ipp/src/request.rs
+++ b/ipp/src/request.rs
@@ -21,8 +21,8 @@ use crate::{
     value::*,
 };
 
-pub const UTF_8_CHARSET: BoundedStr<63> = BoundedStr::const_new("utf-8");
-pub const EN_LANG: BoundedStr<63> = BoundedStr::const_new("en");
+pub const UTF_8_CHARSET: BoundedStrLiteral<63> = BoundedStrLiteral::const_new("utf-8");
+pub const EN_LANG: BoundedStrLiteral<63> = BoundedStrLiteral::const_new("en");
 
 /// IPP request/response struct
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/ipp/src/request.rs
+++ b/ipp/src/request.rs
@@ -51,12 +51,11 @@ impl IppRequestResponse {
         let header = IppHeader::new(version, operation as i16, 1);
         let mut attributes = IppAttributes::new();
 
-        // unwrap is fine because "utf-8" into bounded string is infallible.
         attributes.add(
             DelimiterTag::OperationAttributes,
             IppAttribute::new(
-                IppAttribute::ATTRIBUTES_CHARSET.try_into().unwrap(),
-                IppValue::Charset("utf-8".try_into().unwrap()),
+                IppAttribute::ATTRIBUTES_CHARSET,
+                IppValue::Charset(BoundedStr::const_new("utf-8").into()),
             ),
         );
 
@@ -64,15 +63,15 @@ impl IppRequestResponse {
         attributes.add(
             DelimiterTag::OperationAttributes,
             IppAttribute::new(
-                IppAttribute::ATTRIBUTES_NATURAL_LANGUAGE.try_into().unwrap(),
-                IppValue::NaturalLanguage("en".try_into().unwrap()),
+                IppAttribute::ATTRIBUTES_NATURAL_LANGUAGE,
+                IppValue::NaturalLanguage(BoundedStr::const_new("en").into()),
             ),
         );
 
         if let Some(uri) = uri {
             attributes.add(
                 DelimiterTag::OperationAttributes,
-                IppAttribute::new(IppAttribute::PRINTER_URI.try_into().unwrap(), IppValue::Uri(uri)),
+                IppAttribute::new(IppAttribute::PRINTER_URI, IppValue::Uri(uri)),
             );
         }
 
@@ -94,15 +93,12 @@ impl IppRequestResponse {
 
         response.attributes_mut().add(
             DelimiterTag::OperationAttributes,
-            IppAttribute::new(
-                IppAttribute::ATTRIBUTES_CHARSET.try_into().unwrap(),
-                IppValue::Charset("utf-8".try_into()?),
-            ),
+            IppAttribute::new(IppAttribute::ATTRIBUTES_CHARSET, IppValue::Charset("utf-8".try_into()?)),
         );
         response.attributes_mut().add(
             DelimiterTag::OperationAttributes,
             IppAttribute::new(
-                IppAttribute::ATTRIBUTES_NATURAL_LANGUAGE.try_into().unwrap(),
+                IppAttribute::ATTRIBUTES_NATURAL_LANGUAGE,
                 IppValue::NaturalLanguage("en".try_into()?),
             ),
         );

--- a/ipp/src/request.rs
+++ b/ipp/src/request.rs
@@ -21,8 +21,8 @@ use crate::{
     value::*,
 };
 
-pub const UTF_8_CHARSET: BoundedStrLiteral<63> = BoundedStrLiteral::const_new("utf-8");
-pub const EN_LANG: BoundedStrLiteral<63> = BoundedStrLiteral::const_new("en");
+pub const UTF_8_CHARSET: IppCharsetLiteral = IppCharsetLiteral::const_new("utf-8");
+pub const EN_LANG: IppLanguageLiteral = IppLanguageLiteral::const_new("en");
 
 /// IPP request/response struct
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/ipp/src/request.rs
+++ b/ipp/src/request.rs
@@ -21,6 +21,9 @@ use crate::{
     value::*,
 };
 
+pub const UTF_8_CHARSET: BoundedStr<63> = BoundedStr::const_new("utf-8");
+pub const EN_LANG: BoundedStr<63> = BoundedStr::const_new("en");
+
 /// IPP request/response struct
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct IppRequestResponse {
@@ -55,16 +58,15 @@ impl IppRequestResponse {
             DelimiterTag::OperationAttributes,
             IppAttribute::new(
                 IppAttribute::ATTRIBUTES_CHARSET,
-                IppValue::Charset(BoundedStr::const_new("utf-8").into()),
+                IppValue::Charset(UTF_8_CHARSET.into()),
             ),
         );
 
-        // unwrap is fine because "en" into bounded string is infallible.
         attributes.add(
             DelimiterTag::OperationAttributes,
             IppAttribute::new(
                 IppAttribute::ATTRIBUTES_NATURAL_LANGUAGE,
-                IppValue::NaturalLanguage(BoundedStr::const_new("en").into()),
+                IppValue::NaturalLanguage(EN_LANG.into()),
             ),
         );
 
@@ -93,13 +95,16 @@ impl IppRequestResponse {
 
         response.attributes_mut().add(
             DelimiterTag::OperationAttributes,
-            IppAttribute::new(IppAttribute::ATTRIBUTES_CHARSET, IppValue::Charset("utf-8".try_into()?)),
+            IppAttribute::new(
+                IppAttribute::ATTRIBUTES_CHARSET,
+                IppValue::Charset(UTF_8_CHARSET.into()),
+            ),
         );
         response.attributes_mut().add(
             DelimiterTag::OperationAttributes,
             IppAttribute::new(
                 IppAttribute::ATTRIBUTES_NATURAL_LANGUAGE,
-                IppValue::NaturalLanguage("en".try_into()?),
+                IppValue::NaturalLanguage(EN_LANG.into()),
             ),
         );
 

--- a/ipp/src/util.rs
+++ b/ipp/src/util.rs
@@ -47,7 +47,7 @@ pub fn is_printer_ready(response: &IppRequestResponse) -> Result<bool, IppError>
         return Err(IppError::StatusError(status));
     }
 
-    let printer_state_attr_name: IppName = IppAttribute::PRINTER_STATE.try_into()?;
+    let printer_state_attr_name: IppName = IppAttribute::PRINTER_STATE.into();
 
     let state = response
         .attributes()
@@ -61,7 +61,7 @@ pub fn is_printer_ready(response: &IppRequestResponse) -> Result<bool, IppError>
         return Ok(false);
     }
 
-    let printer_state_reasons_name: IppName = IppAttribute::PRINTER_STATE_REASONS.try_into()?;
+    let printer_state_reasons_name: IppName = IppAttribute::PRINTER_STATE_REASONS.into();
 
     if let Some(reasons) = response
         .attributes()

--- a/ipp/src/value.rs
+++ b/ipp/src/value.rs
@@ -168,7 +168,7 @@ impl<const MAX: usize> BoundedString<MAX> {
 }
 
 impl<const MAX: usize> BoundedStrLiteral<MAX> {
-    /// Constructs a `BoundedStr` from the `&str`
+    /// Constructs a `BoundedStrLiteral` from the `&str`
     ///
     /// # Panics
     ///
@@ -186,7 +186,7 @@ impl<const MAX: usize> BoundedStrLiteral<MAX> {
         Self { inner: value }
     }
 
-    /// Constructs a `BoundedStr` but returns a `Result` rather than panicking,
+    /// Constructs a `BoundedStrLiteral` but returns a `Result` rather than panicking,
     /// making it more appropriate for runtime construction
     pub fn new(value: &'static str) -> Result<Self, IppParseError> {
         let len = value.len();

--- a/ipp/src/value.rs
+++ b/ipp/src/value.rs
@@ -13,7 +13,14 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::{FromPrimitive as _, attribute::IppAttribute, model::ValueTag, parser::IppParseError};
 
-const IPP_STRING_MAX_LENGTH: usize = 1023;
+pub const IPP_STRING_MAX_LENGTH: usize = 1023;
+pub const IPP_SHORT_STRING_LENGTH: usize = 127;
+pub const IPP_KEYWORD_LENGTH: usize = 255;
+pub const IPP_MIME_MEDIA_TYPE_LENGTH: usize = 255;
+pub const IPP_CHARSET_LENGTH: usize = 63;
+pub const IPP_LANGUAGE_LENGTH: usize = 63;
+pub const IPP_NAME_LENGTH: usize = 255;
+pub const IPP_STATUS_MESSAGE_LENGTH: usize = 255;
 
 /// A UTF-8 string whose length is bounded by a compile-time maximum (in bytes).
 ///
@@ -35,29 +42,53 @@ pub struct BoundedString<const MAX: usize = IPP_STRING_MAX_LENGTH> {
 
 /// Const compatible bounded str
 ///
-/// This string type can be constructed at compile time, and converted in an infaillible
-/// manner into a `BoundedString`
+/// This string type can be constructed at compile time from a literal str.
+/// Conversion to `BoundedString` is infaillible so there's no need to handle
+/// impossible `Err()` values
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct BoundedStr<const MAX: usize = IPP_STRING_MAX_LENGTH> {
+pub struct BoundedStrLiteral<const MAX: usize = IPP_STRING_MAX_LENGTH> {
     pub(crate) inner: &'static str,
 }
 
 /// IPP string value with a maximum length of 1023 bytes
 pub type IppString = BoundedString;
+/// Literal equivalent of `IppString`
+pub type IppStrLiteral = BoundedStrLiteral;
+
 /// IPP short string value with a maximum length of 127 bytes
-pub type IppShortString = BoundedString<127>;
+pub type IppShortString = BoundedString<IPP_SHORT_STRING_LENGTH>;
+/// Literal equivalent of `IppShortString`
+pub type IppShortStrLiteral = BoundedStrLiteral<IPP_SHORT_STRING_LENGTH>;
+
 /// IPP keyword value with a maximum length of 255 bytes
-pub type IppKeyword = BoundedString<255>;
+pub type IppKeyword = BoundedString<IPP_KEYWORD_LENGTH>;
+/// Literal equivalent of `IppKeyword`
+pub type IppKeywordLiteral = BoundedStrLiteral<IPP_KEYWORD_LENGTH>;
+
 /// IPP MIME media type value with a maximum length of 255 bytes
-pub type IppMimeMediaType = BoundedString<255>;
+pub type IppMimeMediaType = BoundedString<IPP_MIME_MEDIA_TYPE_LENGTH>;
+// Literal equivalent of `IppMimeMediaType`
+pub type IppMimeMediaTypeLiteral = BoundedStrLiteral<IPP_MIME_MEDIA_TYPE_LENGTH>;
+
 /// IPP charset value with a maximum length of 63 bytes
-pub type IppCharset = BoundedString<63>;
+pub type IppCharset = BoundedString<IPP_CHARSET_LENGTH>;
+// Literal equivalent of `IppCharset`
+pub type IppCharsetLiteral = BoundedStrLiteral<IPP_CHARSET_LENGTH>;
+
 /// IPP natural language tag with a maximum length of 63 bytes
-pub type IppLanguage = BoundedString<63>;
+pub type IppLanguage = BoundedString<IPP_LANGUAGE_LENGTH>;
+// Literal equivalent of `IppLanguage`
+pub type IppLanguageLiteral = BoundedStrLiteral<IPP_LANGUAGE_LENGTH>;
+
 /// IPP name value with a maximum length of 255 bytes
-pub type IppName = BoundedString<255>;
+pub type IppName = BoundedString<IPP_NAME_LENGTH>;
+// Literal equivalent of `IppName`
+pub type IppNameLiteral = BoundedStrLiteral<IPP_NAME_LENGTH>;
+
 /// IPP status-message with a maximum length of 255 bytes
-pub type IppStatusMessage = BoundedString<255>;
+pub type IppStatusMessage = BoundedString<IPP_STATUS_MESSAGE_LENGTH>;
+// Literal equivalent of `IppStatusMessage`
+pub type IppStatusMessageLiteral = BoundedStrLiteral<IPP_STATUS_MESSAGE_LENGTH>;
 
 impl<const MAX: usize> BoundedString<MAX> {
     /// Attempts to create a bounded string from the given value, returning an error if the string's length exceeds the const generic
@@ -136,7 +167,7 @@ impl<const MAX: usize> BoundedString<MAX> {
     }
 }
 
-impl<const MAX: usize> BoundedStr<MAX> {
+impl<const MAX: usize> BoundedStrLiteral<MAX> {
     /// Constructs a `BoundedStr` from the `&str`
     ///
     /// # Panics
@@ -263,33 +294,33 @@ impl<'de, const N: usize> Deserialize<'de> for BoundedString<N> {
     }
 }
 
-impl<const MAX: usize> From<BoundedStr<MAX>> for String {
-    fn from(value: BoundedStr<MAX>) -> Self {
+impl<const MAX: usize> From<BoundedStrLiteral<MAX>> for String {
+    fn from(value: BoundedStrLiteral<MAX>) -> Self {
         value.inner.to_string()
     }
 }
 
-impl<const MAX: usize> From<BoundedStr<MAX>> for BoundedString<MAX> {
-    fn from(value: BoundedStr<MAX>) -> Self {
+impl<const MAX: usize> From<BoundedStrLiteral<MAX>> for BoundedString<MAX> {
+    fn from(value: BoundedStrLiteral<MAX>) -> Self {
         BoundedString {
             inner: value.inner.into(),
         }
     }
 }
 
-impl<const MAX: usize> std::borrow::Borrow<str> for BoundedStr<MAX> {
+impl<const MAX: usize> std::borrow::Borrow<str> for BoundedStrLiteral<MAX> {
     fn borrow(&self) -> &str {
         self.inner
     }
 }
 
-impl<const MAX: usize> AsRef<str> for BoundedStr<MAX> {
+impl<const MAX: usize> AsRef<str> for BoundedStrLiteral<MAX> {
     fn as_ref(&self) -> &str {
         self.inner
     }
 }
 
-impl<const MAX: usize> Deref for BoundedStr<MAX> {
+impl<const MAX: usize> Deref for BoundedStrLiteral<MAX> {
     type Target = str;
 
     fn deref(&self) -> &Self::Target {

--- a/ipp/src/value.rs
+++ b/ipp/src/value.rs
@@ -328,6 +328,12 @@ impl<const MAX: usize> Deref for BoundedStrLiteral<MAX> {
     }
 }
 
+impl<const MAX: usize> fmt::Display for BoundedStrLiteral<MAX> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.inner)
+    }
+}
+
 /// Represents an IPP `text(*)` value with length-tiered encoding.
 ///
 /// IPP defines multiple text encodings depending on maximum length:

--- a/ipp/src/value.rs
+++ b/ipp/src/value.rs
@@ -11,7 +11,7 @@ use num_traits::ToPrimitive;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-use crate::{FromPrimitive as _, model::ValueTag, parser::IppParseError};
+use crate::{FromPrimitive as _, attribute::IppAttribute, model::ValueTag, parser::IppParseError};
 
 const IPP_STRING_MAX_LENGTH: usize = 1023;
 
@@ -31,6 +31,15 @@ const IPP_STRING_MAX_LENGTH: usize = 1023;
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct BoundedString<const MAX: usize = IPP_STRING_MAX_LENGTH> {
     inner: String,
+}
+
+/// Const compatible bounded str
+///
+/// This string type can be constructed at compile time, and converted in an infaillible
+/// manner into a `BoundedString`
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct BoundedStr<const MAX: usize = IPP_STRING_MAX_LENGTH> {
+    pub(crate) inner: &'static str,
 }
 
 /// IPP string value with a maximum length of 1023 bytes
@@ -127,6 +136,38 @@ impl<const MAX: usize> BoundedString<MAX> {
     }
 }
 
+impl<const MAX: usize> BoundedStr<MAX> {
+    /// Constructs a `BoundedStr` from the `&str`
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if the `MAX` size is exceeded
+    ///
+    /// # Examples
+    ///
+    /// This fails at compile time
+    ///
+    /// ```compile_fail
+    /// const IMPOSSIBLE: ipp::value::BoundedStr<4> = ipp::value::BoundedStr::const_new("Hello world");
+    /// ```
+    pub const fn const_new(value: &'static str) -> Self {
+        assert!(value.len() <= MAX);
+        Self { inner: value }
+    }
+
+    /// Constructs a `BoundedStr` but returns a `Result` rather than panicking,
+    /// making it more appropriate for runtime construction
+    pub fn new(value: &'static str) -> Result<Self, IppParseError> {
+        let len = value.len();
+
+        if len > MAX {
+            return Err(IppParseError::InvalidStringLength { len, max: MAX });
+        }
+
+        Ok(Self { inner: value })
+    }
+}
+
 impl<const MAX: usize> From<BoundedString<MAX>> for String {
     fn from(value: BoundedString<MAX>) -> Self {
         value.inner
@@ -219,6 +260,40 @@ impl<'de, const N: usize> Deserialize<'de> for BoundedString<N> {
         } else {
             Ok(Self { inner })
         }
+    }
+}
+
+impl<const MAX: usize> From<BoundedStr<MAX>> for String {
+    fn from(value: BoundedStr<MAX>) -> Self {
+        value.inner.to_string()
+    }
+}
+
+impl<const MAX: usize> From<BoundedStr<MAX>> for BoundedString<MAX> {
+    fn from(value: BoundedStr<MAX>) -> Self {
+        BoundedString {
+            inner: value.inner.into(),
+        }
+    }
+}
+
+impl<const MAX: usize> std::borrow::Borrow<str> for BoundedStr<MAX> {
+    fn borrow(&self) -> &str {
+        self.inner
+    }
+}
+
+impl<const MAX: usize> AsRef<str> for BoundedStr<MAX> {
+    fn as_ref(&self) -> &str {
+        self.inner
+    }
+}
+
+impl<const MAX: usize> Deref for BoundedStr<MAX> {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        self.inner
     }
 }
 
@@ -911,6 +986,19 @@ impl IppValue {
         }
         buffer.freeze()
     }
+
+    /// Turns the `IppValue` into a an `IppAttribute` by adding a name
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use ipp::attribute::*;
+    /// use ipp::value::*;
+    /// let job_id = IppValue::new_integer(1).named(IppAttribute::JOB_ID);
+    /// ```
+    pub fn named(self, name: impl Into<IppName>) -> IppAttribute {
+        IppAttribute::new(name.into(), self)
+    }
 }
 
 /// Implement Display trait to print the value
@@ -1032,7 +1120,12 @@ mod tests {
     use std::{collections::BTreeMap, io};
 
     use super::*;
-    use crate::{attribute::IppAttribute, model::DelimiterTag, parser::IppParser, reader::IppReader};
+    use crate::{
+        attribute::{IppAttribute, IppAttributeName},
+        model::DelimiterTag,
+        parser::IppParser,
+        reader::IppReader,
+    };
 
     #[cfg(feature = "chrono")]
     #[test]
@@ -1261,7 +1354,7 @@ mod tests {
     #[test]
     fn test_array() {
         let attr = IppAttribute::new(
-            "list".try_into().unwrap(),
+            IppAttributeName::const_new("list"),
             IppValue::Array(vec![IppValue::Integer(0x1111_1111), IppValue::Integer(0x2222_2222)]),
         );
         let buf = attr.to_bytes().to_vec();
@@ -1297,7 +1390,7 @@ mod tests {
     #[test]
     fn test_collection() {
         let attr = IppAttribute::new(
-            "coll".try_into().unwrap(),
+            IppAttributeName::const_new("coll"),
             IppValue::Collection(BTreeMap::from([(
                 "abcd".try_into().unwrap(),
                 IppValue::Integer(0x2222_2222),

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -15,7 +15,7 @@ name = "ipputil"
 path = "src/main.rs"
 
 [dependencies]
-ipp = { path = "../ipp", version = "7", default-features = false, optional = true }
+ipp = { path = "../ipp", version = "8", default-features = false, optional = true }
 clap = { version = "4", features = ["derive"] }
 
 [features]

--- a/util/src/main.rs
+++ b/util/src/main.rs
@@ -12,7 +12,7 @@ use std::{
 };
 
 use clap::Parser;
-use ipp::{prelude::*, util};
+use ipp::{prelude::*, util, value::IppName};
 
 fn new_client(uri: Uri, params: &IppParams) -> io::Result<IppClient> {
     let mut builder = IppClient::builder(uri).ignore_tls_errors(params.ignore_tls_errors);
@@ -73,7 +73,7 @@ fn do_print_job(params: &IppParams, cmd: IppPrintCmd) -> Result<(), IppError> {
 
     for arg in cmd.options {
         if let Some((k, v)) = arg.split_once('=') {
-            builder = builder.attribute(IppAttribute::new(k.try_into().unwrap(), v.parse().unwrap()));
+            builder = builder.attribute(IppAttribute::new(IppName::try_from(k).unwrap(), v.parse().unwrap()));
         }
     }
 


### PR DESCRIPTION
This PR adds a `BoundedStr` type which is similar to `BoundedString` except it relies on static strings which makes it possible to use it at compile time (in const values). This makes it possible to turn several faillible operations into infaillible ones, and removes several unwraps().

In this version I have replaced all the `&str` types for attributes name by `BoundedStr` which makes using the crate much easier (IMHO), but is definitely a major change. So another solution might be to generate two list of constants, for backward compatibility.

One example is:
```rust
IppAttribute::new(
    IppAttribute::ATTRIBUTES_NATURAL_LANGUAGE.try_into().unwrap(),
    IppValue::NaturalLanguage("en".try_into().unwrap()),
);
```
which becomes:
```rust

# Must be valid at compile time (fails with a compilation error if the string is too long)
const EN_LANG: BoundedStr<63> = BoundedStr::const_new("en");

# No unwraps
IppAttribute::new(
    IppAttribute::ATTRIBUTES_NATURAL_LANGUAGE,
    IppValue::NaturalLanguage(EN_LANG.into()),
);